### PR TITLE
fix: modified the  git push mikey package name because of composer error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "require-dev": {
             "phpunit/phpunit": "~4.4@dev",
             "sebastian/global-state": "~1.0@dev",
-            "mikey179/vfsStream": "1.4.0"
+            "mikey179/vfsstream": "1.4.0"
         },
 	"minimum-stability" : "dev",
 	"autoload" : {


### PR DESCRIPTION
email 

The oat-sa/lib-flysystem-filecache package of which you are a maintainer has
failed to update due to invalid data contained in your composer.json.
Please address this as soon as possible since the package stopped updating.

It is recommended that you use `composer validate` to check for errors when you
change your composer.json.

Below is the update log which should highlight errors as
"Skipped branch ...":

[Composer\Repository\InvalidRepositoryException]: Some branches contained invalid data and were discarded, it is advised to review the log and fix any issues present in branches

Skipped branch master, Invalid package information:
require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead.

Skipped branch sonarqube-integration, Invalid package information:
require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead.

dev dependencies change
-            "mikey179/vfsstream": "1.4.0"
+            "mikey179/vfsStream": "1.4.0"