### PR TITLE
REL-1455: Issue with partial content requests, audio playback.

### DIFF
--- a/src/LocalCacheAdapter.php
+++ b/src/LocalCacheAdapter.php
@@ -413,10 +413,8 @@ class LocalCacheAdapter extends AbstractAdapter
      * @return array|false false on failure file meta data on success
      */
     public function writeStream($path, $resource, Config $config)
-    {   
-        $result = $this->remoteStorage->writeStream($path, $resource, $config);
-        $this->localStorage->writeStream($path, $this->initStream($resource), $config);
-        return $result;
+    {
+        return $this->write($path, stream_get_contents($resource), $config);
     }
 
     /**


### PR DESCRIPTION
## Goal
This time issue happened during the upload process and it was caused by the behavior of the GCP Bucket adapter which breaks the file stream after reading it causing a problem later on. I’ll prepare a fix that can mitigate the problem.

## Changelog
- fix: some adapters can close the stream after they write data, so we need to make sure we have a copy of the data to write in both adapters.

## How to test / use
1. Open authoring with GCP adpater configured and cache for the adapter enabled.
2. Go to media manager.
3. Try to uplaod a new file.
4. You will get an error.

