### PR TITLE
fix: remove unexisting method

### DIFF
--- a/src/LocalCacheAdapter.php
+++ b/src/LocalCacheAdapter.php
@@ -312,7 +312,7 @@ class LocalCacheAdapter implements FilesystemAdapter
      */
     protected function getListContentsCacheExpectedPath($directory, $recursive)
     {
-        $key = $this->buildCacheKey($this->pathPrefixer->prefixPath($directory));
+        $key = $this->buildCacheKey($this->pathPrefixer->prefixPath($directory) . strval($recursive));
         $expectedPath = ".oat-lib-flysystem-cache/list-contents-cache/${key}.json";
 
         return $expectedPath;

--- a/src/LocalCacheAdapter.php
+++ b/src/LocalCacheAdapter.php
@@ -27,6 +27,7 @@ use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Config;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\PathPrefixer;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -38,6 +39,8 @@ use Psr\Http\Message\StreamInterface;
  */
 class LocalCacheAdapter implements FilesystemAdapter
 {
+    private PathPrefixer $pathPrefixer;
+
     /**
      * remote flysystem adapter
      * @var FilesystemAdapter
@@ -98,11 +101,13 @@ class LocalCacheAdapter implements FilesystemAdapter
     public function __construct(
         FilesystemAdapter $remoteStorage,
         FilesystemAdapter $localStorage,
+        string $path,
         $synchronous = true
     ) {
         $this->remoteStorage = $remoteStorage;
         $this->localStorage = $localStorage;
         $this->synchronous = boolval($synchronous);
+        $this->pathPrefixer = new PathPrefixer($path, DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -281,7 +286,7 @@ class LocalCacheAdapter implements FilesystemAdapter
                 && ($data = $this->localStorage->read($expectedPath)) !== false
             ) {
                 // In cache.
-                $contentList = json_decode($data['contents'], true);
+                $contentList = json_decode($data, true);
             } else {
                 // Not in cache or could not be read.
                 $contentList = $this->remoteStorage->listContents($path, $deep);
@@ -307,7 +312,7 @@ class LocalCacheAdapter implements FilesystemAdapter
      */
     protected function getListContentsCacheExpectedPath($directory, $recursive)
     {
-        $key = $this->buildCacheKey($this->localStorage->getPathPrefix() . $directory . strval($recursive));
+        $key = $this->buildCacheKey($this->pathPrefixer->prefixPath($directory));
         $expectedPath = ".oat-lib-flysystem-cache/list-contents-cache/${key}.json";
 
         return $expectedPath;
@@ -315,7 +320,7 @@ class LocalCacheAdapter implements FilesystemAdapter
 
     protected function getHasDirectoryCacheExpectedPath($path)
     {
-        $key = $this->buildCacheKey($this->localStorage->getPathPrefix() . $path);
+        $key = $this->buildCacheKey($this->pathPrefixer->prefixPath($path));
         $expectedPath = ".oat-lib-flysystem-cache/has-directory-cache/${key}.json";
 
         return $expectedPath;

--- a/test/LocalCacheAdapterTest.php
+++ b/test/LocalCacheAdapterTest.php
@@ -96,7 +96,7 @@ class LocalCacheAdapterTest extends TestCase
         }
         $remoteMock = $remoteProphet->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
 
         $this->assertSame(
             $expected,
@@ -109,7 +109,7 @@ class LocalCacheAdapterTest extends TestCase
         $remoteMock = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter')->reveal();
         $localMock = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter')->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
 
         $this->assertSame($remoteMock, $this->instance->getRemoteStorage());
         $this->assertSame($localMock, $this->instance->getLocalStorage());
@@ -138,7 +138,7 @@ class LocalCacheAdapterTest extends TestCase
         $remoteMock = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter')->reveal();
         $localMock = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter')->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
 
         $this->assertSame($this->instance, $this->instance->setSynchronous($value));
         $this->assertSame($expected, $this->instance->getSynchronous());
@@ -197,7 +197,7 @@ class LocalCacheAdapterTest extends TestCase
 
         $remoteMock = $remoteProphet->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
 
         $this->assertSame($expected, $this->invokeProtectedMethod($this->instance, 'callOnBoth', [$method, $args]));
     }
@@ -409,7 +409,7 @@ class LocalCacheAdapterTest extends TestCase
         $remoteMock = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter')->reveal();
         $localMock = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter')->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
 
         $fixtureStream = tmpfile();
         fputs($fixtureStream, 'test1' . "\n" . 'test2');
@@ -441,7 +441,7 @@ class LocalCacheAdapterTest extends TestCase
         $localMock = $localProphet->reveal();
         $remoteMock = $remoteProphet->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
         $this->instance->writeStream($path, $file, $config);
 
         $this->assertSame($returnDist, $this->instance->readStream($path));
@@ -477,7 +477,7 @@ class LocalCacheAdapterTest extends TestCase
         $localMock = $localProphet->reveal();
         $remoteMock = $remoteProphet->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path/to/file');
         $config = $this->invokeProtectedMethod($this->instance, 'setConfigFromResult', [$fixtureResult]);
         $this->assertInstanceOf('League\Flysystem\Config', $config);
     }

--- a/test/LocalCacheAdapterTest.php
+++ b/test/LocalCacheAdapterTest.php
@@ -34,7 +34,7 @@ class LocalCacheAdapterTest extends TestCase
 
         $synchronous = true;
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, $synchronous);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, $synchronous, '/path/to/file');
 
         $this->assertSame($remoteMock, $this->getInaccessibleProperty($this->instance, 'remoteStorage'));
         $this->assertSame($localMock, $this->getInaccessibleProperty($this->instance, 'localStorage'));

--- a/test/LocalCacheAdapterTest.php
+++ b/test/LocalCacheAdapterTest.php
@@ -400,7 +400,7 @@ class LocalCacheAdapterTest extends TestCase
         $remoteProphet->listContents($fixtureDirectory, $fixtureRecursive)->willReturn($fixtureList);
         $remoteMock = $remoteProphet->reveal();
 
-        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, $config);
+        $this->instance = new LocalCacheAdapter($remoteMock, $localMock, 'path', $config);
         $this->assertSame($fixtureList, $this->instance->listContents($fixtureDirectory, $fixtureRecursive));
     }
 


### PR DESCRIPTION
getPathPrefix method does not exist in LocalStorageAdapter. We need to address cache key build process with PathPrefix object. 

BREAKING CHANGE: LocalCacheAdapter Construct require string with a path