### PR TITLE
fix: invalidate cache if on remote we have newest version

### DIFF
--- a/src/LocalCacheAdapter.php
+++ b/src/LocalCacheAdapter.php
@@ -226,7 +226,7 @@ class LocalCacheAdapter implements FilesystemAdapter
      */
     public function read(string $path): string
     {
-        if (($this->localStorage->fileExists($path)) !== false) {
+        if (($this->localStorage->fileExists($path)) !== false && $this->isLocalLastModified($path)) {
             return $this->localStorage->read($path);
         }
         $result = $this->remoteStorage->read($path);
@@ -246,7 +246,7 @@ class LocalCacheAdapter implements FilesystemAdapter
      */
     public function readStream(string $path)
     {
-        if ($this->localStorage->fileExists($path)) {
+        if ($this->localStorage->fileExists($path) && $this->isLocalLastModified($path)) {
             $result = $this->localStorage->readStream($path);
             if (is_resource($result['stream'] ?? $result)) {
                 return $result['stream'] ?? $result;
@@ -299,6 +299,13 @@ class LocalCacheAdapter implements FilesystemAdapter
         }
 
         return $contentList;
+    }
+
+    protected function isLocalLastModified($path): bool
+    {
+        $localLastModified = $this->localStorage->lastModified($path)->lastModified();
+        $remoteLastModified = $this->remoteStorage->lastModified($path)->lastModified();
+        return $localLastModified > $remoteLastModified;
     }
 
     /**

--- a/test/LocalCacheAdapterTest.php
+++ b/test/LocalCacheAdapterTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Psr7\Utils;
 use League\Flysystem\FileAttributes;
 use oat\flysystem\Adapter\LocalCacheAdapter;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\TextUI\XmlConfiguration\File;
 use Prophecy\Argument;
 use ReflectionClass;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -260,6 +261,14 @@ class LocalCacheAdapterTest extends TestCase
 
         $localProphet->fileExists($path)->willReturn(false !== $localResult);
 
+        $localLastModified = $this->prophesize('League\Flysystem\FileAttributes');
+        $localLastModified->lastModified()->willReturn(2);
+        $remoteLastModified = $this->prophesize('League\Flysystem\FileAttributes');
+        $remoteLastModified->lastModified()->willReturn(1);
+        
+        $localProphet->lastModified($path)->willReturn($localLastModified);
+        $remoteProphet->lastModified($path)->willReturn($remoteLastModified);
+
         if ($localResult === false) {
             $remoteProphet->read($path)->willReturn($remoteResult['contents'] ?? $remoteResult);
         } else {
@@ -342,6 +351,15 @@ class LocalCacheAdapterTest extends TestCase
     {
         $localProphet = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter');
         $remoteProphet = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter');
+
+        $localLastModified = $this->prophesize('League\Flysystem\FileAttributes');
+        $localLastModified->lastModified()->willReturn(2);
+        $remoteLastModified = $this->prophesize('League\Flysystem\FileAttributes');
+        $remoteLastModified->lastModified()->willReturn(1);
+
+        $localProphet->lastModified($path)->willReturn($localLastModified);
+        $remoteProphet->lastModified($path)->willReturn($remoteLastModified);
+
         $config = $this->prophesize('League\Flysystem\Config')->reveal();
 
         $this->instance = $this->createPartialMock(
@@ -430,6 +448,15 @@ class LocalCacheAdapterTest extends TestCase
 
         $localProphet = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter');
         $remoteProphet = $this->prophesize('League\Flysystem\Local\LocalFilesystemAdapter');
+
+        $localLastModified = $this->prophesize('League\Flysystem\FileAttributes');
+        $localLastModified->lastModified()->willReturn(2);
+        $remoteLastModified = $this->prophesize('League\Flysystem\FileAttributes');
+        $remoteLastModified->lastModified()->willReturn(1);
+        
+        $localProphet->lastModified($path)->willReturn($localLastModified);
+        $remoteProphet->lastModified($path)->willReturn($remoteLastModified);
+        
         $config = $this->prophesize('League\Flysystem\Config')->reveal();
 
         $remoteProphet->writeStream($path, Argument::any(), $config);


### PR DESCRIPTION
In case of having multi instances we need to invalidate cache if on the remote storage we have the newest version 