### PR TITLE
fix: update dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,9 @@
   "require": {
     "php": ">=8.1",
     "league/flysystem": "^3.0",
-    "guzzlehttp/psr7": "^1.0"
+    "guzzlehttp/psr7": "^2.0"
   },
+  "prefer-stable": true,
   "require-dev": {
     "mikey179/vfsstream": "1.4.0",
     "phpspec/prophecy": "~1",


### PR DESCRIPTION
We need to update guzzlehttp/psr7` with version `^2.0 to solve security issues
`Root composer.json requires aws/aws-sdk-php 3.336.12 (exact version match: 3.336.12 or 3.336.12.0), found aws/aws-sdk-php[3.336.12] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-dxyf-6n16-t87m") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.` 

`  Problem 1
    - Root composer.json requires oat-sa/extension-tao-system-status 1.8.1 -> satisfiable by oat-sa/extension-tao-system-status[v1.8.1].
    - Root composer.json requires oat-sa/tao-core 54.49.7 -> satisfiable by oat-sa/tao-core[v54.49.7].
    - aws/aws-sdk-php[3.368.0, 3.368.1, 3.368.2, 3.369.0, 3.369.1, 3.369.2, 3.369.3, 3.369.4, 3.369.5, 3.369.6, 3.369.7, 3.369.8, 3.369.9] require guzzlehttp/psr7 ^2.4.5 -> satisfiable by guzzlehttp/psr7[2.4.5, 2.4.x-dev, 2.5.0, 2.5.1, 2.5.x-dev, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.x-dev, 2.7.0, 2.7.1, 2.7.x-dev, 2.8.0, 2.8.x-dev].
    - oat-sa/extension-tao-system-status v1.8.1 requires oat-sa/lib-generis-aws >=0.1.13 -> satisfiable by oat-sa/lib-generis-aws[v0.2, v0.3, v0.4, v0.5.0, v0.6.0, v0.7.0, v0.7.1, v0.7.2, v0.8.0, v0.9.0, v0.9.1, v0.9.2, v0.9.3, v0.9.4, v0.10.0, v0.10.1, v0.11.0, v0.12.0, v0.13.0, v0.14.0, 9999999-dev].
    - oat-sa/lib-generis-aws[dev-master, v0.2, v0.3, v0.4, v0.5.0, v0.6.0, v0.7.0, v0.7.1, v0.7.2, v0.8.0, v0.9.0, v0.9.1, v0.9.2, v0.9.3, v0.9.4, v0.10.0, v0.10.1, v0.11.0, v0.12.0, v0.13.0, v0.14.0] require aws/aws-sdk-php ^3.0.0 -> satisfiable by aws/aws-sdk-php[3.0.x-dev, 3.368.0, 3.368.1, 3.368.2, 3.369.0, 3.369.1, 3.369.2, 3.369.3, 3.369.4, 3.369.5, 3.369.6, 3.369.7, 3.369.8, 3.369.9].
    - oat-sa/tao-core v54.49.7 requires guzzlehttp/psr7 ^1.8.4 -> satisfiable by guzzlehttp/psr7[1.9.1, 1.9.x-dev].
    - You can only install one version of a package, so only one of these can be installed: guzzlehttp/psr7[1.9.1, 1.9.x-dev, 2.4.5, 2.4.x-dev, 2.6.2, 2.6.3, 2.6.x-dev, 2.7.0, 2.7.1, 2.7.x-dev, 2.8.0, 2.8.x-dev].`
